### PR TITLE
Robin/patchify speed

### DIFF
--- a/pathaia/patches/functional_api.py
+++ b/pathaia/patches/functional_api.py
@@ -161,7 +161,15 @@ def slide_rois(
 
 
 def patchify_slide(
-    slidefile, outdir, level, psize, interval, offset=None, filters=None, verbose=2
+    slidefile,
+    outdir,
+    level,
+    psize,
+    interval,
+    offset=None,
+    filters=None,
+    erase_tree=None,
+    verbose=2,
 ):
     """
     Save patches of a given wsi.
@@ -174,6 +182,7 @@ def patchify_slide(
         interval (dictionary): {"x", "y"} interval between 2 neighboring patches.
         offset (dictionary): {"x", "y"} offset in px on x and y axis for patch start.
         filters (list of func): filters to accept patches.
+        erase_tree (bool): whether to erase outfolder if it exists. If None, user will be prompted for a choice.
         verbose (int): 0 => nada, 1 => patchifying parameters, 2 => start-end of processes, thumbnail export.
 
     """
@@ -188,8 +197,10 @@ def patchify_slide(
     else:
         slide_folder_output = os.path.join(outdir, slide_id)
         if os.path.isdir(slide_folder_output):
-            safe_rmtree(slide_folder_output, ignore_errors=True)
-        os.makedirs(slide_folder_output)
+            erase_tree = safe_rmtree(
+                slide_folder_output, ignore_errors=True, erase_tree=erase_tree
+            )
+        os.makedirs(slide_folder_output, exist_ok=True)
 
     if verbose > 0:
         print("patchifying: {}".format(slidefile))
@@ -205,8 +216,8 @@ def patchify_slide(
     # level directory
     outleveldir = os.path.join(slide_folder_output, "level_{}".format(level))
     if os.path.isdir(outleveldir):
-        safe_rmtree(outleveldir, ignore_errors=True)
-    os.makedirs(outleveldir)
+        safe_rmtree(outleveldir, ignore_errors=True, erase_tree=erase_tree)
+    os.makedirs(outleveldir, exist_ok=True)
     ########################
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -246,6 +257,7 @@ def patchify_slide_hierarchically(
     offset=None,
     filters=None,
     silent=None,
+    erase_tree=None,
     verbose=2,
 ):
     """
@@ -261,6 +273,7 @@ def patchify_slide_hierarchically(
         offset (dictionary): {"x", "y"} offset in px on x and y axis for patch start.
         filters (dict of list of func): filters to accept patches.
         silent (list of int): pyramid level not to output.
+        erase_tree (bool): whether to erase outfolder if it exists. If None, user will be prompted for a choice.
         verbose (int): 0 => nada, 1 => patchifying parameters, 2 => start-end of processes, thumbnail export.
 
     """
@@ -277,8 +290,10 @@ def patchify_slide_hierarchically(
     else:
         slide_folder_output = os.path.join(outdir, slide_id)
         if os.path.isdir(slide_folder_output):
-            safe_rmtree(slide_folder_output, ignore_errors=True)
-        os.makedirs(slide_folder_output)
+            erase_tree = safe_rmtree(
+                slide_folder_output, ignore_errors=True, erase_tree=erase_tree
+            )
+        os.makedirs(slide_folder_output, exist_ok=True)
 
     csv_columns = ["id", "parent", "level", "x", "y", "dx", "dy"]
     csv_path = os.path.join(slide_folder_output, "patches.csv")
@@ -303,8 +318,8 @@ def patchify_slide_hierarchically(
             # level directory
             outleveldir = os.path.join(slide_folder_output, "level_{}".format(level))
             if os.path.isdir(outleveldir):
-                safe_rmtree(outleveldir, ignore_errors=True)
-            os.makedirs(outleveldir)
+                safe_rmtree(outleveldir, ignore_errors=True, erase_tree=erase_tree)
+            os.makedirs(outleveldir, exist_ok=True)
             ########################
             if level not in silent:
                 with warnings.catch_warnings():
@@ -362,6 +377,7 @@ def patchify_folder(
     extensions=(".mrxs",),
     recurse=False,
     folders=None,
+    erase_tree=None,
     verbose=2,
 ):
     """
@@ -378,11 +394,12 @@ def patchify_folder(
         extensions (list of str): list of file extensions to consider. Defaults to '.mrxs'.
         recurse (bool): whether to look for files recursively.
         folders (list of str): list of subfolders to explore when recurse is True. Defaults to all.
+        erase_tree (bool): whether to erase outfolder if it exists. If None, user will be prompted for a choice.
         verbose (int): 0 => nada, 1 => patchifying parameters, 2 => start-end of processes, thumbnail export.
 
     """
     if os.path.isdir(outfolder):
-        safe_rmtree(outfolder, ignore_errors=True)
+        erase_tree = safe_rmtree(outfolder, ignore_errors=True, erase_tree=erase_tree)
     offset = ifnone(offset, {"x": 0, "y": 0})
     filters = ifnone(filters, [])
     slidefiles = get_files(
@@ -398,8 +415,8 @@ def patchify_folder(
         slidename = slide_basename(slidefile)
         outdir = os.path.join(outfolder, slidename)
         if os.path.isdir(outdir):
-            safe_rmtree(outdir, ignore_errors=True)
-        os.makedirs(outdir)
+            safe_rmtree(outdir, ignore_errors=True, erase_tree=erase_tree)
+        os.makedirs(outdir, exist_ok=True)
         patchify_slide(
             slidefile,
             outdir,
@@ -408,6 +425,7 @@ def patchify_folder(
             interval,
             offset=offset,
             filters=filters,
+            erase_tree=erase_tree,
             verbose=verbose,
         )
 
@@ -425,6 +443,7 @@ def patchify_folder_hierarchically(
     extensions=(".mrxs",),
     recurse=False,
     folders=None,
+    erase_tree=None,
     verbose=2,
 ):
     """
@@ -443,11 +462,12 @@ def patchify_folder_hierarchically(
         extensions (list of str): list of file extensions to consider. Defaults to '.mrxs'.
         recurse (bool): whether to look for files recursively.
         folders (list of str): list of subfolders to explore when recurse is True. Defaults to all.
+        erase_tree (bool): whether to erase outfolder if it exists. If None, user will be prompted for a choice.
         verbose (int): 0 => nada, 1 => patchifying parameters, 2 => start-end of processes, thumbnail export.
 
     """
     if os.path.isdir(outfolder):
-        safe_rmtree(outfolder, ignore_errors=True)
+        erase_tree = safe_rmtree(outfolder, ignore_errors=True, erase_tree=erase_tree)
     offset = ifnone(offset, {"x": 0, "y": 0})
     filters = ifnone(filters, {})
     silent = ifnone(silent, [])
@@ -463,8 +483,8 @@ def patchify_folder_hierarchically(
         slidename = slide_basename(slidefile)
         outdir = os.path.join(outfolder, slidename)
         if os.path.isdir(outdir):
-            safe_rmtree(outdir, ignore_errors=True)
-        os.makedirs(outdir)
+            safe_rmtree(outdir, ignore_errors=True, erase_tree=erase_tree)
+        os.makedirs(outdir, exist_ok=True)
         patchify_slide_hierarchically(
             slidefile,
             outdir,
@@ -475,6 +495,7 @@ def patchify_folder_hierarchically(
             offset=offset,
             filters=filters,
             silent=silent,
+            erase_tree=erase_tree,
             verbose=verbose,
         )
 
@@ -488,6 +509,7 @@ def extract_tissue_patch_coords(
     extensions=(".mrxs",),
     recurse=True,
     folders=None,
+    erase_tree=None,
 ):
     """
     Extracts all patch coordinates that contain tissue at aspecific level from WSI files
@@ -502,8 +524,12 @@ def extract_tissue_patch_coords(
         extensions (list of str): list of file extensions to consider. Defaults to '.mrxs'.
         recurse (bool): whether to look for files recursively.
         folders (list of str): list of subfolders to explore when recurse is True. Defaults to all.
+        erase_tree (bool): whether to erase outfolder if it exists. If None, user will be prompted for a choice.
     """
     outfolder = Path(outfolder)
+    if outfolder.is_dir():
+        erase_tree = safe_rmtree(outfolder, ignore_errors=True, erase_tree=erase_tree)
+    outfolder.mkdir(parents=True, exist_ok=True)
     overlap_size = psize - interval
     files = get_files(infolder, extensions=extensions, recurse=recurse, folder=folders)
 

--- a/pathaia/util/paths.py
+++ b/pathaia/util/paths.py
@@ -168,7 +168,7 @@ def get_files(path, extensions=None, recurse=True, folders=None, followlinks=Tru
     return L(res)
 
 
-def safe_rmtree(path, ignore_errors=True):
+def safe_rmtree(path, ignore_errors=True, erase_tree=None):
     """
     Safe version of rmtree that asks for permission before deleting.
 
@@ -177,22 +177,18 @@ def safe_rmtree(path, ignore_errors=True):
         ignore_error (bool): whether to ignore errors or not.
 
     Returns:
-        bool: whether the folder was succesfully deleted or not
+        bool: True if erase_tree==True or if user gave permission.
     """
     response = ""
-    while response not in ["y", "n"]:
-        response = input(
-            "Are you sure you want to delete " f"{path} and all subfolders ? y/n"
-        )
-        response = response.lower()
-    if response == "y":
-        try:
-            shutil.rmtree(path, ignore_errors=False)
-            return True
-        except Exception as e:
-            if ignore_errors:
-                return False
-            else:
-                raise e
+    if erase_tree is None:
+        while response not in ["y", "n"]:
+            response = input(
+                "Are you sure you want to delete " f"{path} and all subfolders ? y/n"
+            )
+            response = response.lower()
+
+    if response == "y" or erase_tree:
+        shutil.rmtree(path, ignore_errors=ignore_errors)
+        return True
     else:
         return False


### PR DESCRIPTION
**NE PAS MERGE POUR L'INSTANT**

Deux modifications principales ici.
* Comme dit précédemment, je pense qu'il vaut mieux éviter les `shutil.rmtree`. Si l'utilisateur veut réécrire sur le même dossier, il peut le supprimer à la main normalement. En attendant j'ai remplacer par une fonction `safe_rmtree` qui demande la permission de supprimer. Du coup j'ai rajouter dans tes fonctions `patchify` un appel de cette fonction sur le dossier `outfolder` entier, histoire d'éviter d'avoir à entrer la confirmation pour chaque slide si on confirme vouloir changer le dossier. Pour l'instant j'ai modifié de manière brute tous les appels à `shutil.rmtree` par cette nouvelle fonction, mais je pense que ce n'est pas suffisant. Par exemple, j'imagine que si le dossier n'a pas été correctement supprimé (soit parce que l'utilisateur a refusé, soit parce que ça n'a pas fonctionné), il vaut mieux arrêter la fonction. Pour ça ma fonction renvoie `False` quand ça n'a pas fonctionné de manière générale, donc on peut éventuellement en faire quelque chose sur ce point. Dans tous les cas je pense qu'il est important de clarifier dans quels cas on veut que les dossiers soient supprimés, dans quels cas on pourrait juste spécifier `exists_ok=True` dans `os.makedirs`. Par exemple si on veut pouvoir reprendre un travail interrompu pour x ou y raison, ne pas supprimer le dossier d'output peut être une option. D'où le fait que pour moi si l'utilisateur veut repartir de 0 il devrait supprimer le dossier manuellement. Sinon une autre option c'est de checker si les dossiers existent en début de fonction, s'ils existent on demande si l'utilisateur veut supprimer les dossiers ou continuer à travailler dans les dossiers existant, et passer la réponse à cette question dans toutes les sous-fonctions, de sorte qu'il n'y ait pas besoin de redemander par la suite mais que si la sous-fonction est appelée explicitement dans un script la question soit quand même posée. Je sais pas si c'est clair mais je pense que c'est une bonne solution qui évitera les comportements imprévus et permettra de ne pas avoir à faire la suppression manuelle. Si ça te va j'implémente ça.
* J'ai ajouté une fonction que j'avais codée qui permet de récupérer les coordonnées des patchs situés dans le tissus à partir d'un filtrage fait sur la miniature plutôt que sur chaque patch. Autant dire que ça fait gagner beaucoup de temps. Le truc c'est que je voudrais intégrer ça correctement dans ton API, c'est à dire ajouter partout la possibilité de filtrer sur la miniature plutôt que sur le patch, et de modifier ma fonction pour qu'elle aussi supporte les deux options (et pour qu'elle fonctionne globalement exactement comme tes fonctions, sauf qu'elle ne sauvegarde pas les patchs sur disque mais seulement le csv). En gros pour moi il faudrait rajouter un argument `save_patch_on_disk` ou équivalent et ne garder que tes deux fonctions `patchify` adaptées pour supporter le filtrage sur miniature. Ca te paraît ok comme stratégie ? Tu as une idée de comment intégrer le filtrage sur miniature ?