### PR TITLE
nlyFluo slide filters

### DIFF
--- a/pathaia/patches/errors.py
+++ b/pathaia/patches/errors.py
@@ -53,3 +53,13 @@ class HasNoDataFolder(PathaiaWarning):
     """
 
     pass
+
+
+class InvalidArgument(Error):
+    """
+    Raise when trying to read mrxs with no data folder.
+
+    ***************************************************
+    """
+
+    pass

--- a/pathaia/patches/functional_api.py
+++ b/pathaia/patches/functional_api.py
@@ -19,7 +19,7 @@ from .filters import (
     filter_has_tissue_he,
     standardize_filters,
 )
-from .slide_filters import filter_thumbnail
+from .slide_filters import filter_thumbnail, filter_fluo_thumbnail
 from .compat import convert_coords
 import os
 import csv
@@ -35,7 +35,10 @@ izi_filters = {
     "has-tissue-he": filter_has_tissue_he,
 }
 
-slide_filters = {"full": filter_thumbnail}
+slide_filters = {
+    "full": filter_thumbnail,
+    "fluo": filter_fluo_thumbnail
+}
 
 
 def filter_image(image: NDImage, filters: Sequence[Filter]) -> bool:


### PR DESCRIPTION
A couple of new features:

- Added a fluorescence slide filter for DAPI
- Added a `silence` parameter to patch generation functions. It enables full silent extraction on non-hierarchical patches using `slide_rois_no_image` (only create the csv without writing any png file).