### PR TITLE
Refactored and debugged graph API

### DIFF
--- a/pathaia/graphs/__init__.py
+++ b/pathaia/graphs/__init__.py
@@ -1,0 +1,2 @@
+from .graph import *
+from .functional_api import *

--- a/pathaia/graphs/__init__.py
+++ b/pathaia/graphs/__init__.py
@@ -1,2 +1,2 @@
-from .graph import *
+from .object_api import *
 from .functional_api import *

--- a/pathaia/graphs/clustering.py
+++ b/pathaia/graphs/clustering.py
@@ -4,8 +4,8 @@ import numpy as np
 from tqdm import tqdm
 from typing import Tuple, Any, Union, Dict, Sequence, Optional
 from nptyping import NDArray
-from .types import Parenthood, NumericalNodeProperty, Node, Edge
-from .graph import UGraph, Tree
+from .types import Node, Edge
+from .object_api import UGraph, Tree
 
 
 class AgglomerativeClustering:
@@ -315,82 +315,3 @@ class AgglomerativeClustering:
             nodeprops["population"][n] = self.populations_[n]
 
         return Tree(nodes, parents, children, nodeprops, edgeprops)
-
-
-class UFDS:
-    """
-    Union-find data structure for felzenszwalb algorithm.
-    Each unionFind instance X maintains a family of disjoint sets of
-    hashable objects, supporting the following two methods:
-    - X[item] returns a name for the set containing the given item.
-      Each set is named by an arbitrarily-chosen one of its members; as
-      long as the set remains unchanged it will keep the same name. If
-      the item is not yet part of a set in X, a new singleton set is
-      created for it.
-    - X.union(item1, item2, ...) merges the sets containing each item
-      into a single larger set.  If any item is not yet part of a set
-      in X, it is added to X as one of the members of the merged set.
-      Union-find data structure. Based on Josiah Carlson's code,
-      http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/215912
-      with significant additional changes by D. Eppstein.
-      http://www.ics.uci.edu/~eppstein/PADS/UnionFind.py
-    """
-
-    def __init__(self):
-        """
-        Create a new empty union-find structure.
-        ****************************************
-        """
-        # UFDS permit to compute the hierarchy
-        # it is responsible to keep track of:
-        # the parent is crucial, but it only guarantee the tree structure
-        # should not be used outside of the object
-        self._parent: Parenthood = {}
-        # size is subjective, it is only used to fuse objects, no real quantitative interest
-        # should not be used outside of the object
-        self._size: NumericalNodeProperty = {}
-
-    def get_root(self, node: Node) -> Node:
-        """
-        Find and return the name of the set containing the node.
-        ********************************************************
-        """
-        # check for previously unknown object
-        # if unknown, create an entry in the parent dico
-        # then, size is set to 1
-        # intra is set to 0
-        if node not in self._parent:
-            self._parent[node] = node
-            self._size[node] = 1
-            return node
-        # find path of objects leading to the root
-        path = [node]
-        root = self._parent[node]
-        while root != path[-1]:
-            path.append(root)
-            root = self._parent[root]
-        # compress the path and return
-        for ancestor in path:
-            self._parent[ancestor] = root
-        return root
-
-    def __iter__(self):
-        """
-        Iterate through all items ever found or unioned by this structure.
-        ******************************************************************
-        """
-        return iter(self.parents)
-
-    def union(self, edge: Edge):
-        """
-        Find the sets containing the objects and merge them all.
-        ********************************************************
-        """
-        n1, n2 = edge
-        roots = [self.get_root(n1), self.get_root(n2)]
-        # Find the heaviest root according to its weight.
-        heaviest = max(roots, key=lambda r: self._size[r])
-        for r in roots:
-            if r != heaviest:
-                self._size[heaviest] += self._size[r]
-                self._parent[r] = heaviest

--- a/pathaia/graphs/errors.py
+++ b/pathaia/graphs/errors.py
@@ -43,6 +43,13 @@ class UndefinedChildhood(Error):
     pass
 
 
+class InvalidTree(Error):
+    """
+    Raise when parents and children do no match.
+    *********************************************
+    """
+
+
 class UnknownNodeProperty(Error):
     """
     Raise when trying to access unknown level.

--- a/pathaia/graphs/functional_api.py
+++ b/pathaia/graphs/functional_api.py
@@ -20,7 +20,7 @@ from .errors import (
     UnrelatedNode,
     UnknownNodeProperty
 )
-from .clustering import UFDS
+from .kruskal import UFDS
 import json
 
 

--- a/pathaia/graphs/functional_api.py
+++ b/pathaia/graphs/functional_api.py
@@ -13,15 +13,46 @@ from .types import (
     Childhood,
     Edge,
     EdgeProperties,
-    NumericalEdgeProperty)
+    NumericalEdgeProperty,
+)
 from .errors import (
     InvalidEdgeProps,
     InvalidNodeProps,
     UnrelatedNode,
-    UnknownNodeProperty
+    UnknownNodeProperty,
+    InvalidTree,
 )
 from .kruskal import UFDS
 import json
+
+
+def complete_tree(
+    parents: Optional[Parenthood] = None, children: Optional[Childhood] = None
+):
+    if parents is None:
+        parents = {}
+        if children is None:
+            children = {}
+        else:
+            for parent in children:
+                children[parent] = set(children[parent])
+                for child in children[parent]:
+                    parents[child] = parent
+    else:
+        if children is None:
+            children = {}
+            for child, parent in parents.items():
+                try:
+                    children[parent].add(child)
+                except KeyError:
+                    children[parent] = {child}
+        else:
+            for parent in children:
+                children[parent] = set(children[parent])
+                for child in children[parent]:
+                    if child not in parents or parents[child] != parent:
+                        raise InvalidTree
+    return parents, children
 
 
 def get_root(parents: Parenthood, node: Node = None) -> Node:
@@ -57,9 +88,7 @@ def get_root_path(parents: Parenthood, node: Node) -> List[Node]:
     return root_path
 
 
-def get_root_path_match(
-    parents: Parenthood, node: Node, target: Node
-) -> List[Node]:
+def get_root_path_match(parents: Parenthood, node: Node, target: Node) -> List[Node]:
     """
     Get path to root of a node in a tree.
     *************************************
@@ -79,10 +108,7 @@ def get_root_path_match(
         root_path.append(root)
 
 
-def get_leaves_without_prop(
-    children: Childhood,
-    node: Node,
-) -> List[Node]:
+def get_leaves_without_prop(children: Childhood, node: Node,) -> List[Node]:
     """
     Get leaves of a node in a tree.
     *******************************
@@ -104,9 +130,7 @@ def get_leaves_without_prop(
 
 
 def get_leaves_with_prop(
-    children: Childhood,
-    node: Node,
-    prop: BinaryNodeProperty
+    children: Childhood, node: Node, prop: BinaryNodeProperty
 ) -> List[Node]:
     """
     Get leaves of a node in a tree.
@@ -146,9 +170,7 @@ def get_leaves_with_prop(
 
 
 def get_leaves(
-    children: Childhood,
-    node: Node,
-    prop: Optional[BinaryNodeProperty] = None
+    children: Childhood, node: Node, prop: Optional[BinaryNodeProperty] = None
 ) -> List[Node]:
     """
     Get leaves of a node in a tree.
@@ -188,9 +210,7 @@ def kruskal_edges(
 
 
 def kruskal_tree(
-    edges: Sequence[Edge],
-    weights: NumericalEdgeProperty,
-    size: NumericalNodeProperty
+    edges: Sequence[Edge], weights: NumericalEdgeProperty, size: NumericalNodeProperty
 ) -> Tuple[Parenthood, Childhood, NumericalNodeProperty]:
     """
     Create parents an children relationships from kruskal edges.
@@ -233,7 +253,7 @@ def tree_to_json(
     children: Childhood,
     jsonfile: str,
     nodeprops: Optional[NodeProperties] = None,
-    edgeprops: Optional[EdgeProperties] = None
+    edgeprops: Optional[EdgeProperties] = None,
 ):
     """Store a jsonified tree to a json file."""
     output_dict = dict()
@@ -269,7 +289,7 @@ def _expand_on_property(
     cut: List[Node],
     children: Childhood,
     prop: NumericalNodeProperty,
-    threshold: Union[int, float]
+    threshold: Union[int, float],
 ) -> List[Node]:
     """Create a new tree by cutting based on property threshold."""
     candidates = []
@@ -288,7 +308,7 @@ def cut_on_property(
     parents: Parenthood,
     children: Childhood,
     prop: NumericalNodeProperty,
-    threshold: Union[int, float]
+    threshold: Union[int, float],
 ) -> List[Node]:
     """Produce a list of authorized nodes given a property threshold."""
     root = get_root(parents)
@@ -300,11 +320,7 @@ def cut_on_property(
     return list(cut)
 
 
-def common_ancestor(
-    parents: Parenthood,
-    node1: Node,
-    node2: Node
-) -> Node:
+def common_ancestor(parents: Parenthood, node1: Node, node2: Node) -> Node:
     """Get the common ancestor of two nodes and store their distances to him."""
     if node1 in parents and node2 in parents:
         rp1 = get_root_path(parents, node1)
@@ -317,17 +333,11 @@ def common_ancestor(
             "Nodes {} and {} have no common ancestors!!!".format(node1, node2)
         )
     raise UnrelatedNode(
-        "One of the provided nodes: ({}, {}) has no parent...".format(
-            node1, node2
-        )
+        "One of the provided nodes: ({}, {}) has no parent...".format(node1, node2)
     )
 
 
-def edge_dist(
-    parents: Parenthood,
-    node1: Node,
-    node2: Node
-) -> int:
+def edge_dist(parents: Parenthood, node1: Node, node2: Node) -> int:
     """Return the number of edges to go from node1 to node2 (by common ancestor)."""
     ancestor = common_ancestor(parents, node1, node2)
     rpm1 = get_root_path_match(parents, node1, ancestor)
@@ -336,23 +346,22 @@ def edge_dist(
 
 
 def weighted_dist(
-    parents: Parenthood,
-    weights: NumericalNodeProperty,
-    node1: Node,
-    node2: Node
+    parents: Parenthood, weights: NumericalNodeProperty, node1: Node, node2: Node
 ) -> float:
     """Return the number of edges to go from node1 to node2 (by common ancestor)."""
     ancestor = common_ancestor(parents, node1, node2)
     rpm1 = get_root_path_match(parents, node1, ancestor)
     rpm2 = get_root_path_match(parents, node2, ancestor)
-    nodes_in_path = (set(rpm1) | set(rpm2))
+    nodes_in_path = set(rpm1) | set(rpm2)
     nodes_in_path.discard(node1)
     nodes_in_path.discard(node2)
-    dist = 0.
+    dist = 0.0
     for node in nodes_in_path:
         if node not in weights:
             raise UnknownNodeProperty(
-                "Missing weight for node {} to compute a weighted distance!!!".format(node)
+                "Missing weight for node {} to compute a weighted distance!!!".format(
+                    node
+                )
             )
         dist += weights[node]
     # minus 1 otherwise ancestor is counted twice

--- a/pathaia/graphs/graph.py
+++ b/pathaia/graphs/graph.py
@@ -248,7 +248,7 @@ class Tree(Graph):
             self.parents_[child] = parent
             edges.append((parent, child))
         try:
-            self.children_[parent] |= children
+            self.children_[parent] |= set(children)
         except KeyError:
             self.children_[parent] = set(children)
         super().add_edges(edges, update_A=update_A)

--- a/pathaia/graphs/graph.py
+++ b/pathaia/graphs/graph.py
@@ -215,22 +215,21 @@ class Tree(Graph):
             self.from_json(jsonfile)
         else:
             edges = []
-            for node in children:
-                edges.extend([(node, child) for child in children[node]])
+            self.parents_ = ifnone(parents, {})
+            self.children_ = ifnone(children, {})
+            for node in self.children_:
+                self.children_[node] = set(self.children_[node])
+                edges.extend([(node, child) for child in self.children_[node]])
             super().__init__(
                 self, nodes=nodes, edges=edges, nodeprops=nodeprops, edgeprops=edgeprops
             )
-            self.parents_ = ifnone(parents, {})
-            self.children_ = ifnone(
-                {parent: set(children[parent]) for parent in children}, {}
-            )
 
     @property
-    def parents(self):
+    def parents(self) -> Parenthood:
         return self.parents_
 
     @property
-    def children(self):
+    def children(self) -> Childhood:
         return self.children_
 
     def add_edge(self, parent: Node, child: Node, update_A: bool = True):

--- a/pathaia/graphs/graph.py
+++ b/pathaia/graphs/graph.py
@@ -248,7 +248,7 @@ class Tree(Graph):
             self.parents_[child] = parent
             edges.append((parent, child))
         try:
-            self.children_[parent].extend(children)
+            self.children_[parent] |= children
         except KeyError:
             self.children_[parent] = set(children)
         super().add_edges(edges, update_A=update_A)

--- a/pathaia/graphs/kruskal.py
+++ b/pathaia/graphs/kruskal.py
@@ -1,0 +1,80 @@
+from .types import Parenthood, NumericalNodeProperty, Node, Edge
+
+
+class UFDS:
+    """
+    Union-find data structure for felzenszwalb algorithm.
+    Each unionFind instance X maintains a family of disjoint sets of
+    hashable objects, supporting the following two methods:
+    - X[item] returns a name for the set containing the given item.
+      Each set is named by an arbitrarily-chosen one of its members; as
+      long as the set remains unchanged it will keep the same name. If
+      the item is not yet part of a set in X, a new singleton set is
+      created for it.
+    - X.union(item1, item2, ...) merges the sets containing each item
+      into a single larger set.  If any item is not yet part of a set
+      in X, it is added to X as one of the members of the merged set.
+      Union-find data structure. Based on Josiah Carlson's code,
+      http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/215912
+      with significant additional changes by D. Eppstein.
+      http://www.ics.uci.edu/~eppstein/PADS/UnionFind.py
+    """
+
+    def __init__(self):
+        """
+        Create a new empty union-find structure.
+        ****************************************
+        """
+        # UFDS permit to compute the hierarchy
+        # it is responsible to keep track of:
+        # the parent is crucial, but it only guarantee the tree structure
+        # should not be used outside of the object
+        self._parent: Parenthood = {}
+        # size is subjective, it is only used to fuse objects, no real quantitative interest
+        # should not be used outside of the object
+        self._size: NumericalNodeProperty = {}
+
+    def get_root(self, node: Node) -> Node:
+        """
+        Find and return the name of the set containing the node.
+        ********************************************************
+        """
+        # check for previously unknown object
+        # if unknown, create an entry in the parent dico
+        # then, size is set to 1
+        # intra is set to 0
+        if node not in self._parent:
+            self._parent[node] = node
+            self._size[node] = 1
+            return node
+        # find path of objects leading to the root
+        path = [node]
+        root = self._parent[node]
+        while root != path[-1]:
+            path.append(root)
+            root = self._parent[root]
+        # compress the path and return
+        for ancestor in path:
+            self._parent[ancestor] = root
+        return root
+
+    def __iter__(self):
+        """
+        Iterate through all items ever found or unioned by this structure.
+        ******************************************************************
+        """
+        return iter(self.parents)
+
+    def union(self, edge: Edge):
+        """
+        Find the sets containing the objects and merge them all.
+        ********************************************************
+        """
+        n1, n2 = edge
+        roots = [self.get_root(n1), self.get_root(n2)]
+        # Find the heaviest root according to its weight.
+        heaviest = max(roots, key=lambda r: self._size[r])
+        for r in roots:
+            if r != heaviest:
+                self._size[heaviest] += self._size[r]
+                self._parent[r] = heaviest

--- a/pathaia/graphs/object_api.py
+++ b/pathaia/graphs/object_api.py
@@ -1,5 +1,5 @@
 """Classes used to represent graphs."""
-from typing import List, Sequence, Optional, Union
+from typing import List, Sequence, Optional, Union, Tuple
 import json
 from scipy.sparse import spmatrix, dok_matrix
 import numpy as np
@@ -62,7 +62,7 @@ class Graph:
                 self.nodes_ = OrderedSet(np.arange(A.shape[0]))
                 self.edges_ = []
                 for i, j in zip(*A.nonzero()):
-                    self.edges_.appends((i, j))
+                    self.edges_.append((i, j))
                     self.A_[i, j] = True
             else:
                 self.edges_ = []
@@ -77,7 +77,7 @@ class Graph:
             elif A is not None:
                 self.edges_ = []
                 for i, j in zip(*A.nonzero()):
-                    self.edges_.appends((i, j))
+                    self.edges_.append((self.nodes_[i], self.nodes_[j]))
                     self.A_[i, j] = True
             else:
                 self.edges_ = []
@@ -87,7 +87,7 @@ class Graph:
 
     @property
     def n_nodes(self):
-        return self.nodes_
+        return len(self.nodes_)
 
     @property
     def nodes(self):
@@ -221,7 +221,7 @@ class Tree(Graph):
             self.children_[parent] = set(children)
         super().add_edges(edges)
 
-    def add_edges(self, edges: Sequence[Node, Union[Node, Sequence[Node]]]):
+    def add_edges(self, edges: Sequence[Tuple[Node, Union[Node, Sequence[Node]]]]):
         for p, c in edges:
             if isinstance(c, Node):
                 self.add_edge(p, c)

--- a/pathaia/graphs/types.py
+++ b/pathaia/graphs/types.py
@@ -3,6 +3,12 @@ from typing import Union, Dict, List, Tuple
 Node = Union[int, str, tuple]
 Edge = Tuple[Node, Node]
 
+
+class UEdge(tuple):
+    def __new__(self, edge: Edge, key=None):
+        return tuple.__new__(UEdge, sorted(edge, key=key))
+
+
 NodeEndomorphism = Dict[Node, Node]
 Parenthood = Dict[Node, Node]
 Childhood = Dict[Node, List[Node]]

--- a/tests/graphs/test_object_api.py
+++ b/tests/graphs/test_object_api.py
@@ -1,0 +1,66 @@
+from pathaia.graphs import Graph, UGraph, Tree
+from scipy.sparse import csr_matrix
+from pytest import raises
+import itertools
+from ordered_set import OrderedSet
+
+
+def test_graph_init():
+    nodes_init = (None, (1, 2, 3), "123")
+    edges_init = (None, ((1, 3), (1, 2), (2, 1)))
+    A_init = (None, csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool))
+
+    expected = (
+        (OrderedSet(), [], csr_matrix((0, 0), dtype=bool)),
+        (
+            OrderedSet((0, 1, 2)),
+            [(0, 1), (1, 2)],
+            csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool),
+        ),
+        (
+            OrderedSet((1, 3, 2)),
+            [(1, 3), (1, 2), (2, 1)],
+            csr_matrix(((1, 1, 1), ((0, 0, 2), (1, 2, 0))), shape=(3, 3), dtype=bool),
+        ),
+        (
+            OrderedSet((1, 3, 2)),
+            [(1, 3), (1, 2), (2, 1)],
+            csr_matrix(((1, 1, 1), ((0, 0, 2), (1, 2, 0))), shape=(3, 3), dtype=bool),
+        ),
+        (OrderedSet((1, 2, 3)), [], csr_matrix((3, 3), dtype=bool)),
+        (
+            OrderedSet((1, 2, 3)),
+            [(1, 2), (2, 3)],
+            csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool),
+        ),
+        (
+            OrderedSet((1, 2, 3)),
+            [(1, 3), (1, 2), (2, 1)],
+            csr_matrix(((1, 1, 1), ((0, 0, 1), (2, 1, 0))), shape=(3, 3), dtype=bool),
+        ),
+        (
+            OrderedSet((1, 2, 3)),
+            [(1, 3), (1, 2), (2, 1)],
+            csr_matrix(((1, 1, 1), ((0, 0, 1), (2, 1, 0))), shape=(3, 3), dtype=bool),
+        ),
+        (OrderedSet(("1", "2", "3")), [], csr_matrix((3, 3), dtype=bool)),
+        (
+            OrderedSet(("1", "2", "3")),
+            [("1", "2"), ("2", "3")],
+            csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool),
+        ),
+        KeyError,
+        KeyError,
+    )
+
+    for exp, (nodes, edges, A) in zip(
+        expected, itertools.product(nodes_init, edges_init, A_init)
+    ):
+        if isinstance(exp, tuple):
+            exp_nodes, exp_edges, exp_A = exp
+            G = Graph(nodes, edges, A)
+            assert G.nodes == exp_nodes
+            assert G.edges == exp_edges
+            assert (G.A[G.A > 0] == exp_A[exp_A > 0]).A.all()
+        else:
+            assert raises(exp, Graph, nodes, edges, A)

--- a/tests/graphs/test_object_api.py
+++ b/tests/graphs/test_object_api.py
@@ -11,42 +11,42 @@ def test_graph_init():
     A_init = (None, csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool))
 
     expected = (
-        (OrderedSet(), [], csr_matrix((0, 0), dtype=bool)),
+        (OrderedSet(), set(), csr_matrix((0, 0), dtype=bool)),
         (
             OrderedSet((0, 1, 2)),
-            [(0, 1), (1, 2)],
+            {(0, 1), (1, 2)},
             csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool),
         ),
         (
             OrderedSet((1, 3, 2)),
-            [(1, 3), (1, 2), (2, 1)],
+            {(1, 3), (1, 2), (2, 1)},
             csr_matrix(((1, 1, 1), ((0, 0, 2), (1, 2, 0))), shape=(3, 3), dtype=bool),
         ),
         (
             OrderedSet((1, 3, 2)),
-            [(1, 3), (1, 2), (2, 1)],
+            {(1, 3), (1, 2), (2, 1)},
             csr_matrix(((1, 1, 1), ((0, 0, 2), (1, 2, 0))), shape=(3, 3), dtype=bool),
         ),
-        (OrderedSet((1, 2, 3)), [], csr_matrix((3, 3), dtype=bool)),
+        (OrderedSet((1, 2, 3)), set(), csr_matrix((3, 3), dtype=bool)),
         (
             OrderedSet((1, 2, 3)),
-            [(1, 2), (2, 3)],
+            {(1, 2), (2, 3)},
             csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool),
         ),
         (
             OrderedSet((1, 2, 3)),
-            [(1, 3), (1, 2), (2, 1)],
+            {(1, 3), (1, 2), (2, 1)},
             csr_matrix(((1, 1, 1), ((0, 0, 1), (2, 1, 0))), shape=(3, 3), dtype=bool),
         ),
         (
             OrderedSet((1, 2, 3)),
-            [(1, 3), (1, 2), (2, 1)],
+            {(1, 3), (1, 2), (2, 1)},
             csr_matrix(((1, 1, 1), ((0, 0, 1), (2, 1, 0))), shape=(3, 3), dtype=bool),
         ),
-        (OrderedSet(("1", "2", "3")), [], csr_matrix((3, 3), dtype=bool)),
+        (OrderedSet(("1", "2", "3")), set(), csr_matrix((3, 3), dtype=bool)),
         (
             OrderedSet(("1", "2", "3")),
-            [("1", "2"), ("2", "3")],
+            {("1", "2"), ("2", "3")},
             csr_matrix(((1, 1), ((0, 1), (1, 2))), shape=(3, 3), dtype=bool),
         ),
         KeyError,
@@ -61,6 +61,25 @@ def test_graph_init():
             G = Graph(nodes, edges, A)
             assert G.nodes == exp_nodes
             assert G.edges == exp_edges
-            assert (G.A[G.A > 0] == exp_A[exp_A > 0]).A.all()
+            assert (G.A[G.A > 0].A == exp_A[exp_A > 0].A).all()
         else:
             assert raises(exp, Graph, nodes, edges, A)
+
+
+def test_ugraph_init():
+    nodes = (1, 2, 3)
+    edges = ((1, 3), (1, 2), (2, 1))
+    A = None
+
+    exp_nodes, exp_edges, exp_A = (
+        OrderedSet((1, 2, 3)),
+        {(1, 2), (1, 3)},
+        csr_matrix(
+            ((1, 1, 1, 1), ((0, 1, 0, 2), (1, 0, 2, 0))), shape=(3, 3), dtype=bool
+        ),
+    )
+
+    G = UGraph(nodes, edges, A)
+    assert G.nodes == exp_nodes
+    assert G.edges == exp_edges
+    assert (G.A[G.A > 0].A == exp_A[exp_A > 0].A).all()

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ envlist = py35, py36, py37, py38
 deps = 
     coverage
     pytest
+    ordered-set
 commands =
   coverage run --source pathaia -m pytest tests --verbose
   coverage xml


### PR DESCRIPTION
* Made internal attributes for graphs protected so that user is incentivised to use `add_node` and `add_edge` to modify the graph and keep it consistent.
* Adjacency matrix is now of fixed size internally and is sliced when property is accessed. 
* Adjacency matrix is now internally stored as a DictionaryOfKey sparse matrix but returned as a CompressedSparseRow matrix when accessed through public property.
* Adjacency matrix is now always updated when edges are added or removed.
* Added `remove_edge` and `remove_node` for graphs.
* Added `add_edge`, `add_edges` and `add_children` for tree. Method signature is voluntarily different from `Graph` given that tree are often not used in the same way.
* Modified `Tree.from_json` and `Tree.build_kruskal` to use newly added methods and keep all attributes consistent.
* Corrected `Tree.__init__` (could try to iterate over `None` and did not consistently define children as `Dict[Node, Set[Node]]`).
* `Tree.__init__` now only uses info from `jsonfile` when specified. Giving other parameters to the constructor is useless.
* Made `AgglomerativeClstering` internal attributes private to match scikit-learn API.
* Created `init_graph` in `AgglomerativeClustering` for more clarity.
* Renamed `graph.py` to `object_api.py` to keep consistent with other modules.
* Moved `UFDS` to a new `kruskal.py` file to avoid circular imports.
* Added `UEdge` type for undirected edges that always sorts edges according to node indexes.
* Added some tests.