### PR TITLE
Fix slide_rois and preview_from_queries

### DIFF
--- a/.github/workflows/tests_run.yml
+++ b/.github/workflows/tests_run.yml
@@ -23,7 +23,7 @@ jobs:
         run: pip install tox
       - name: Test with tox
         run: tox -e py
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./coverage.xml

--- a/pathaia/patches/functional_api.py
+++ b/pathaia/patches/functional_api.py
@@ -150,13 +150,12 @@ def slide_rois(
         patches = []
         for ancestor in ancestors:
             # ancestor is a patch
-            rx, ry = ancestor.position
             prefix = ancestor.id
             k = 0
             for patch_coord in regular_grid(shape, interval, psize):
                 k += 1
                 idx = "{}#{}".format(prefix, k)
-                position = patch_coord * mag + ry
+                position = patch_coord * mag + ancestor.position
                 patches.append(
                     Patch(
                         id=idx,
@@ -253,13 +252,12 @@ def slide_rois_no_image(
         size_0 = psize * mag
         for ancestor in ancestors:
             # ancestor is a patch
-            rx, ry = ancestor.position
             prefix = ancestor.id
             k = 0
             for patch_coord in regular_grid(shape, interval, psize):
                 k += 1
                 idx = "{}#{}".format(prefix, k)
-                position = patch_coord * mag + ry
+                position = patch_coord * mag + ancestor.position
                 yield Patch(
                     id=idx,
                     slidename=slide._filename.split("/")[-1],

--- a/pathaia/patches/visu.py
+++ b/pathaia/patches/visu.py
@@ -36,7 +36,7 @@ def preview_from_queries(
     # get thumbnail first
     slide_size = Coord(slide.dimensions)
     if size_0 is None:
-        size_0 = Coord(queries[0].size_0)
+        size_0 = Coord(queries[0].size_0) if len(queries) != 0 else Coord(min_res)
     thickness = 2 * (thickness // 2) + 1
     res = slide_size / size_0 * (thickness + cell_size) + thickness
     thumb_w = max(min_res, res.x)
@@ -50,8 +50,8 @@ def preview_from_queries(
     grid = numpy.zeros((thumb_size.y, thumb_size.x), numpy.uint8)
     for query in queries:
         # position in queries are absolute
-        x, y = int(query.position[0] / dsr_x), int(query.position[1] / dsr_y)
-        dx, dy = int(query.size_0[0] / dsr_x), int(query.size_0[1] / dsr_y)
+        x, y = round(query.position[0] / dsr_x), round(query.position[1] / dsr_y)
+        dx, dy = round(query.size_0[0] / dsr_x), round(query.size_0[1] / dsr_y)
         #? startx = numpy.clip(x, 0, thumb_size.x - 1)
         startx = min(x, thumb_size.x - 1)
         starty = min(y, thumb_size.y - 1)

--- a/pathaia/patches/visu.py
+++ b/pathaia/patches/visu.py
@@ -43,25 +43,26 @@ def preview_from_queries(
     thumb_h = max(min_res, res.y)
     image = slide.get_thumbnail((thumb_w, thumb_h))
     thumb_size = Coord(image.size)
-    dsr = slide_size[0] / thumb_size[0]
+    dsr_x = slide_size[0] / thumb_size[0]
+    dsr_y = slide_size[1] / thumb_size[1]
     image = numpy.array(image)[:, :, 0:3]
     # get grid
-    grid = 255 * numpy.ones((thumb_size.y, thumb_size.x), numpy.uint8)
+    grid = numpy.zeros((thumb_size.y, thumb_size.x), numpy.uint8)
     for query in queries:
         # position in queries are absolute
-        x, y = query.position / dsr
-        dx, dy = query.size_0 / dsr
+        x, y = int(query.position[0] / dsr_x), int(query.position[1] / dsr_y)
+        dx, dy = int(query.size_0[0] / dsr_x), int(query.size_0[1] / dsr_y)
+        #? startx = numpy.clip(x, 0, thumb_size.x - 1)
         startx = min(x, thumb_size.x - 1)
         starty = min(y, thumb_size.y - 1)
         endx = min(x + dx, thumb_size.x - 1)
         endy = min(y + dy, thumb_size.y - 1)
         # horizontal segments
-        grid[starty, startx:endx] = 0
-        grid[endy, startx:endx] = 0
+        grid[starty, startx:endx] = 1
+        grid[endy - 1, startx:endx] = 1
         # vertical segments
-        grid[starty:endy, startx] = 0
-        grid[starty:endy, endx] = 0
-    grid = grid < 255
+        grid[starty:endy, startx] = 1
+        grid[starty:endy, endx - 1] = 1
     d = disk(thickness//2)
     grid = binary_dilation(grid, d)
     image[grid] = color

--- a/pathaia/util/types.py
+++ b/pathaia/util/types.py
@@ -1,5 +1,4 @@
 from typing import (
-    Any,
     Callable,
     Dict,
     Sequence,
@@ -140,28 +139,28 @@ Filter = Sequence[Union[str, Callable]]
 FilterList = Union[str, Sequence[Filter], Dict[int, Sequence[Filter]]]
 PathLike = Union[str, os.PathLike]
 
-NDByteImage = NDArray[Shape["N, N, 3"], numpy.uint8]
-NDFloat32Image = NDArray[Shape["N, N, 3"], numpy.float32]
-NDFloat64Image = NDArray[Shape["N, N, 3"], numpy.float64]
+NDByteImage = NDArray[Shape["*, *, 3"], numpy.uint8]
+NDFloat32Image = NDArray[Shape["*, *, 3"], numpy.float32]
+NDFloat64Image = NDArray[Shape["*, *, 3"], numpy.float64]
 NDFloatImage = Union[NDFloat32Image, NDFloat64Image]
 NDImage = Union[NDByteImage, NDFloatImage]
 
-NDByteGrayImage = NDArray[Shape["N, N"], numpy.uint8]
-NDFloat32GrayImage = NDArray[Shape["N, N"], numpy.float32]
-NDFloat64GrayImage = NDArray[Shape["N, N"], numpy.float64]
+NDByteGrayImage = NDArray[Shape["*, *"], numpy.uint8]
+NDFloat32GrayImage = NDArray[Shape["*, *"], numpy.float32]
+NDFloat64GrayImage = NDArray[Shape["*, *"], numpy.float64]
 NDFloatGrayImage = Union[NDFloat32GrayImage, NDFloat64GrayImage]
 NDGrayImage = Union[NDByteGrayImage, NDFloatGrayImage]
 
-NDBoolMask = NDArray[Shape["N, N"], numpy.bool8]
-NDBoolMaskBatch = NDArray[Shape["N, N, N"], numpy.bool8]
+NDBoolMask = NDArray[Shape["*, *"], numpy.bool8]
+NDBoolMaskBatch = NDArray[Shape["*, *, *"], numpy.bool8]
 
-NDIntMask2d = NDArray[Shape["N, N"], numpy.int32]
-NDIntMask3d = NDArray[Shape["N, N, N"], numpy.int32]
-NDIntMask4d = NDArray[Shape["N, N, N, N"], numpy.int32]
+NDIntMask2d = NDArray[Shape["*, *"], numpy.int32]
+NDIntMask3d = NDArray[Shape["*, *, *"], numpy.int32]
+NDIntMask4d = NDArray[Shape["*, *, *, *"], numpy.int32]
 
-NDByteImageBatch = NDArray[Shape["N, N, N, 3"], numpy.uint8]
-NDFloat32ImageBatch = NDArray[Shape["N, N, N, 3"], numpy.float32]
-NDFloat64ImageBatch = NDArray[Shape["N, N, N, 3"], numpy.float64]
+NDByteImageBatch = NDArray[Shape["*, *, *, 3"], numpy.uint8]
+NDFloat32ImageBatch = NDArray[Shape["*, *, *, 3"], numpy.float32]
+NDFloat64ImageBatch = NDArray[Shape["*, *, *, 3"], numpy.float64]
 NDFloatImageBatch = Union[NDFloat32ImageBatch, NDFloat64ImageBatch]
 NDImageBatch = Union[NDByteImageBatch, NDFloatImageBatch]
 


### PR DESCRIPTION
Fixed a bug in slide_rois that made the patches not correctly aligned with the ancestors and in fact overwriting each other in the patches.csv file. The same bug was present in slide_rois_no_image.

I had a shift with the preview_from_queries function that made the resulting patches not match what was visible on the thumbnail. The problem seems to be solved with this version. Also wouldn't the idea be to do startx = numpy.clip(x, 0, thumb_size.x - 1) instead of startx = min(x, thumb_size.x - 1) ? Same question with the three variables below.

And in util.types.py I replaced the " N " with " * " which allow the images to not have same width and height : isinstance(numpy.ones(3, 2),  NDArray[Shape["N, N"], numpy.uint8]) return False
but
isinstance(numpy.ones(3, 2),  NDArray[Shape["*, *"], numpy.uint8]) return True